### PR TITLE
two "make test" issues

### DIFF
--- a/3270Medium_HQ.sfd
+++ b/3270Medium_HQ.sfd
@@ -27879,7 +27879,7 @@ EndSplineSet
 Validated: 1
 EndChar
 
-StartChar: Omega
+StartChar: Omega.greek
 Encoding: 937 937 1145
 Width: 536
 VWidth: 0

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ uninstall:
 zip: all
 	@zip 3270_fonts_$(shell git rev-parse --short HEAD).zip 3270Medium.* 3270SemiNarrow.* 3270Narrow.*
 
-test: all
+test: derived
 	@fontlint 3270Medium.otf
 	@fontlint 3270Medium.pfm
 	@fontlint 3270Medium.ttf


### PR DESCRIPTION
There are two problems with "make test":
- because of a pointless dependency on "all", it requires a bunch of python-pil stuff.  That'd require everyone who wants to build your font from source to install PIL.  It's not that fat a dependency, but since there's no gain from it unless one wants the sample image, it's better to not require it.  I've also added a "make fonts" target that generates just the font files but not the sample image.
- with non-ancient fontforge versions that @copyninja plans to upload to Debian unstable in the next few days, the validation fails with:

```
Attempt to unget two characters
CHECKING     3270Medium.otf
The glyph named Omega is mapped to U+03A9.
  But its name indicates it should be mapped to U+2126.
PASS         3270Medium.otf

Copyright (c) 2000-2014 by George Williams. See AUTHORS for Contributors.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
 Based on sources from 20161015-ML-D.
 Based on source from git with hash: 
Attempt to unget two characters
CHECKING     3270Medium.pfm
ERROR     22 Two glyphs have the same Unicode code point
FAIL         3270Medium.pfm
```

This looks like a bug in Fontforge to me, as you request "Omega" (ie U+03A9 GREEK CAPITAL LETTER OMEGA) rather than U+2126 OHM SIGN, but since the workaround is so simple (s/Omega/Omega.greek/), it's easier to just do so.
