### PR TITLE
Add target for font-only generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ endif
 .SUFFIXES:
 
 all: derived sample
+
 font: derived
 
 derived: 3270Medium_HQ.sfd

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ endif
 .SUFFIXES:
 
 all: derived sample
+font: derived
 
 derived: 3270Medium_HQ.sfd
 	@./generate_derived.pe
@@ -21,6 +22,7 @@ sample: derived
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  all        Generates the TrueType, OpenType, Type-1, WebFont files and sample image."
+	@echo "  font       Generates the font, as with 'all', without the sample image"
 	@echo "  install    Copies the generated OTF fonts into the system-appropriate folder (Ubuntu, Fedora, OSX)."
 	@echo "  uninstall  Uninstalls the generated OTF fonts."
 	@echo "  zip        Creates the ZIP archive to be sent to S3 (the 'binary build')."


### PR DESCRIPTION
For anyone who just wants the font, having to install PIL just to generate the preview isn't really needed.
(was looking to make an Aur package, and having PIL as a build dep seems excessive).