### PR TITLE
Add the ablity to generate the font files using containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.fedoraproject.org/fedora-minimal:latest
+
+WORKDIR /opt
+
+RUN microdnf install -y fontforge make

--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,9 @@ cask: zip  ## Generate the font cask file (requires Homebrew)
 ifeq ($(UNAME),Darwin)
 	@${FONTCASKER} ${BUILD_DIR}/3270_fonts_$(shell git rev-parse --short HEAD).zip
 endif
+
+image: # Builds the container image
+	docker build -t 3270font:latest .
+
+generate: # Generates the fonts using the container image
+	docker run --rm -v ${PWD}:/opt 3270font:latest make font

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ ifeq ($(UNAME),Darwin)
 	@${FONTCASKER} ${BUILD_DIR}/3270_fonts_$(shell git rev-parse --short HEAD).zip
 endif
 
-image: # Builds the container image
+image: ## Builds the container image
 	docker build -t 3270font:latest .
 
 generate: ## Generates the fonts using the container image

--- a/Makefile
+++ b/Makefile
@@ -139,5 +139,5 @@ endif
 image: # Builds the container image
 	docker build -t 3270font:latest .
 
-generate: # Generates the fonts using the container image
+generate: ## Generates the fonts using the container image
 	docker run --rm -v ${PWD}:/opt 3270font:latest make font

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ In order to generate the sample image and the grids for FontForge,
 you'll need a Python 3 environment with PIL or pillow installed. The
 requirements.txt file lists everything you need to do it.
 
+If all you want is an easier way to provide feedback, you can use
+a container runtime, Docker, Podman, and etc, and use these make targets:
+
+  - ```make image``` - builds a local image with ```fontforge``` and ```make```
+  - ```make generate``` -  uses the local container image to run ```make font```
+
+
 Screenshots
 -----------
 


### PR DESCRIPTION
Added the following Makefile targets:

- ```make image``` builds an image with ```fontforge``` and ```make```
- ```make generate``` uses the container image to run ```make font```

I think this can help development by other project members and can be used to overhaul, a bit, of the building process.

Thoughts?